### PR TITLE
Use raw input values so controller triggers work when only right controller is active

### DIFF
--- a/Assets/MixedRealityToolkit.ThirdParty/OculusQuestInput/Scripts/Input/Controllers/OculusQuestController.cs
+++ b/Assets/MixedRealityToolkit.ThirdParty/OculusQuestInput/Scripts/Input/Controllers/OculusQuestController.cs
@@ -125,13 +125,13 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             bool isGripPressed = false;
             if (ControllerHandedness == Handedness.Left)
             {
-                isTriggerPressed = OVRInput.Get(OVRInput.Axis1D.PrimaryIndexTrigger) > cTriggerDeadZone;
-                isGripPressed = OVRInput.Get(OVRInput.Axis1D.PrimaryHandTrigger) > cTriggerDeadZone;
+                isTriggerPressed = OVRInput.Get(OVRInput.RawAxis1D.LIndexTrigger) > cTriggerDeadZone;
+                isGripPressed = OVRInput.Get(OVRInput.RawAxis1D.LHandTrigger) > cTriggerDeadZone;
             }
             else
             {
-                isTriggerPressed = OVRInput.Get(OVRInput.Axis1D.SecondaryIndexTrigger) > cTriggerDeadZone;
-                isGripPressed = OVRInput.Get(OVRInput.Axis1D.SecondaryHandTrigger) > cTriggerDeadZone;
+                isTriggerPressed = OVRInput.Get(OVRInput.RawAxis1D.RIndexTrigger) > cTriggerDeadZone;
+                isGripPressed = OVRInput.Get(OVRInput.RawAxis1D.RHandTrigger) > cTriggerDeadZone;
             }
 
             for (int i = 0; i < Interactions?.Length; i++)


### PR DESCRIPTION
Avoids bug in Oculus API where right hand controller is mapped as Primary when the left controller is inactive contrary to Oculus docs.