### PR TITLE
Added SymLink Shell script for macOS & updated README

### DIFF
--- a/External/createSymlink.sh
+++ b/External/createSymlink.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cd `dirname $0`
+
+FOLDERS_TO_LINK=(
+    MixedRealityToolkit
+    MixedRealityToolkit.SDK
+    MixedRealityToolkit.Services
+    MixedRealityToolkit.Providers
+    MixedRealityToolkit.Examples
+    MixedRealityToolkit.Extensions
+    MixedRealityToolkit.Tools
+)
+
+for folder in "${FOLDERS_TO_LINK[@]}"
+do
+ln -s MixedRealityToolkit-Unity/Assets/$folder ../Assets/$folder
+ln -s MixedRealityToolkit-Unity/Assets/$folder.meta ../Assets/$folder.meta
+done

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then clone using this command "git clone --recurse-submodules https://github.com
 This will the official MRTK development branch as well. If you'd like your own version of MRTK, simply remove "--recurse-submodules" from the command, and copy your MRTK files to the External folder, before proceeding to step 2.
 
 ## 2. Run SymLink bat
-Run bat External/createSymlink.bat by double clicking it.
+On Windows run the bat External/createSymlink.bat by double clicking it. On OS X execute the shell script via "./createSymlink.sh".
 This will link the MRTK folders cloned via the submodule into the project.
 
 ## 3. Import Oculus Integration


### PR DESCRIPTION
Since macOS users cannot run .bat files to create symlinks, a corresponding shell script ist needed.