### PR TITLE
Fixed relative path issue where symlinks would reference themselves

### DIFF
--- a/External/createSymlink.sh
+++ b/External/createSymlink.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd `dirname $0`
+cd `dirname $0`/../Assets/
 
 FOLDERS_TO_LINK=(
     MixedRealityToolkit
@@ -14,6 +14,6 @@ FOLDERS_TO_LINK=(
 
 for folder in "${FOLDERS_TO_LINK[@]}"
 do
-ln -s MixedRealityToolkit-Unity/Assets/$folder ../Assets/$folder
-ln -s MixedRealityToolkit-Unity/Assets/$folder.meta ../Assets/$folder.meta
+ln -s ../External/MixedRealityToolkit-Unity/Assets/$folder $folder
+ln -s ../External/MixedRealityToolkit-Unity/Assets/$folder.meta $folder.meta
 done


### PR DESCRIPTION
Fixed bug where symlinks to files & folders would point to themselves instead of the originals from the submodule.

I tested the final setup again via macOS on the Quest and everything seems to work fine.