### PR TITLE
Fix bug related to avatar hands not getting properly placed in hierarchy

### DIFF
--- a/Assets/MixedRealityToolkit.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
+++ b/Assets/MixedRealityToolkit.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
@@ -75,6 +75,15 @@ namespace prvncher.MixedReality.Toolkit.Config
         public OVRCameraRig OVRCameraRigPrefab => ovrCameraRigPrefab;
 
         [SerializeField]
+        [Tooltip("Use this if you want to manage the avatar hands prefab yourself.")]
+        private bool allowDevToManageAvatarPrefab = false;
+
+        /// <summary>
+        /// Use this if you want to manage the avatar hands prefab yourself.
+        /// </summary>
+        public bool AllowDevToManageAvatarPrefab => allowDevToManageAvatarPrefab;
+
+        [SerializeField]
         [Tooltip("Prefab reference for LocalAvatar to load, if none are found in scene.")]
         private GameObject localAvatarPrefab = null;
 

--- a/Assets/MixedRealityToolkit.ThirdParty/MRTK-Quest/Scripts/Input/OculusQuestInputManager.cs
+++ b/Assets/MixedRealityToolkit.ThirdParty/MRTK-Quest/Scripts/Input/OculusQuestInputManager.cs
@@ -100,6 +100,8 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 // Instantiate camera rig as a child of the MixedRealityPlayspace
                 cameraRig = GameObject.Instantiate(MRTKOculusConfig.Instance.OVRCameraRigPrefab);
             }
+            // Ensure all related game objects are configured
+            cameraRig.EnsureGameObjectIntegrity();
 
             bool useAvatarHands = MRTKOculusConfig.Instance.RenderAvatarHandsInsteadOfController;
             // If using Avatar hands, de-activate ovr controller rendering
@@ -108,7 +110,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 controllerHelper.gameObject.SetActive(!useAvatarHands);
             }
 
-            if (useAvatarHands)
+            if (useAvatarHands && !MRTKOculusConfig.Instance.AllowDevToManageAvatarPrefab)
             {
                 // Initialize the local avatar controller
                 GameObject.Instantiate(MRTKOculusConfig.Instance.LocalAvatarPrefab, cameraRig.trackingSpace);


### PR DESCRIPTION
- Previously, attempted to parent avatar prefab to tracking space, before it was configured. Added call to Oculus SDK to ensure tracking space is configured before organizing hierarchy accordingly.

Solves issue #38 