### PR TITLE
allow hand-curl grip

### DIFF
--- a/Assets/MixedRealityToolkit.ThirdParty/MRTK-Quest/Scripts/Input/Controllers/OculusQuestHand.cs
+++ b/Assets/MixedRealityToolkit.ThirdParty/MRTK-Quest/Scripts/Input/Controllers/OculusQuestHand.cs
@@ -343,6 +343,22 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
             // Pinch was also used as grab, we want to allow hand-curl grab not just pinch.
             // Determine pinch and grab separately
+            CheckIfJointPosesGrabbing();
+
+            if (MRTKOculusConfig.Instance.UpdateMaterialPinchStrengthValue && handMaterial != null)
+            {
+                if (IsGrabbing)
+                {
+                    pinchStrength = 1.0f;
+                }
+                handMaterial.SetFloat(pinchStrengthProp, pinchStrength);
+            }
+
+            return isTracked;
+        }
+
+        protected void CheckIfJointPosesGrabbing()
+        {
             MixedRealityPose wristPose, indexKnucklePose, indexTipPose;
             if (jointPoses.TryGetValue(TrackedHandJoint.Wrist, out wristPose))
             {
@@ -351,21 +367,12 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                     if (jointPoses.TryGetValue(TrackedHandJoint.IndexKnuckle, out indexKnucklePose))
                     {
                         // compare wrist-knuckle to wrist-tip
-                        float wristToIndexTip = Vector3.Distance(wristPose.Position, indexTipPose.Position);
-                        float wristToIndexKnuckle = Vector3.Distance(wristPose.Position, indexKnucklePose.Position);
-                        bool grip = wristToIndexKnuckle >= wristToIndexTip;
-
-                        IsGrabbing = grip;
+                        Vector3 wristToIndexTip = indexTipPose.Position - wristPose.Position;
+                        Vector3 wristToIndexKnuckle = indexKnucklePose.Position - wristPose.Position;
+                        IsGrabbing = wristToIndexKnuckle.sqrMagnitude >= wristToIndexTip.sqrMagnitude;
                     }
                 }
             }
-
-            if (MRTKOculusConfig.Instance.UpdateMaterialPinchStrengthValue && handMaterial != null)
-            {
-                handMaterial.SetFloat(pinchStrengthProp, IsGrabbing ? 1.0f : pinchStrength);
-            }
-
-            return isTracked;
         }
 
         // 4 cm is the treshold for fingers being far apart.


### PR DESCRIPTION
Per discussion at https://github.com/microsoft/MixedRealityToolkit-Unity/issues/7965#issuecomment-634222183

Here is a quick implementation that addresses the ArticulatedHand's mistake equating pinch-select with grab for the OculusQuestHand, in the hopes that others find this useful as well.

The change is not specific to OculusQuestHand, so perhaps we should propose this as a change to the ArticulatedHand behavior in MRTK Core once we have an implementation here that we like enough.