### PR TITLE
gracefully allow coexistence by not destroying main camera

### DIFF
--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/OculusQuestInputManager.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/OculusQuestInputManager.cs
@@ -89,24 +89,20 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             cameraRig = GameObject.FindObjectOfType<OVRCameraRig>();
             if (cameraRig == null)
             {
-                // Temporarily disable camera destruction.
-                // Not having an OVRCameraRig causes bugs at runtime.
-                /*
                 var mainCamera = Camera.main;
-                Transform cameraParent = null;
-                if (mainCamera != null)
-                {
-                    cameraParent = mainCamera.transform.parent;
-
-                    // Destroy main camera
-                    GameObject.Destroy(cameraParent.gameObject);
-                }
 
                 // Instantiate camera rig as a child of the MixedRealityPlayspace
                 cameraRig = GameObject.Instantiate(MRTKOculusConfig.Instance.OVRCameraRigPrefab);
-                */
-                UnityEngine.Debug.LogError("No OVR Camera Rig found. Could not initialize MRTK-Quest.");
-                return;
+
+                if (mainCamera != null)
+                {
+                    // We already had a main camera MRTK probably started using, let's replace the CenterEyeAnchor MainCamera with it
+                    GameObject prefabMainCamera = cameraRig.trackingSpace.Find("CenterEyeAnchor").gameObject;
+                    prefabMainCamera.SetActive(false);
+                    mainCamera.transform.SetParent(cameraRig.trackingSpace.transform);
+                    mainCamera.name = prefabMainCamera.name;
+                    GameObject.Destroy(prefabMainCamera);
+                }
             }
             // Ensure all related game objects are configured
             cameraRig.EnsureGameObjectIntegrity();


### PR DESCRIPTION
This allows the Quest to use the MRTK standard scene's MixedRealityPlayspace with Main Camera.