### PR TITLE
Teleport options

### DIFF
--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputPointerProfile.asset
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputPointerProfile.asset
@@ -1,0 +1,66 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db393d206eab4604ab74278cb6cda355, type: 3}
+  m_Name: MRTK-Quest_InputPointerProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 1
+  pointingExtent: 10
+  pointingRaycastLayerMasks:
+  - serializedVersion: 2
+    m_Bits: 4294967291
+  debugDrawPointingRays: 1
+  debugDrawPointingRayColors:
+  - {r: 1, g: 0.58280706, b: 0, a: 1}
+  - {r: 0.86426115, g: 1, b: 0, a: 1}
+  - {r: 0, g: 1, b: 0.2163105, a: 1}
+  - {r: 0, g: 0.3028021, b: 1, a: 1}
+  - {r: 0.44855833, g: 0, b: 1, a: 1}
+  gazeCursorPrefab: {fileID: 1000012072213228, guid: 5b3e2856904e43c680f84f326861032a,
+    type: 3}
+  gazeProviderType:
+    reference: Microsoft.MixedReality.Toolkit.Input.GazeProvider, Microsoft.MixedReality.Toolkit.Services.InputSystem
+  useHeadGazeOverride: 1
+  isEyeTrackingEnabled: 0
+  pointerOptions:
+  - controllerType: 1071
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
+      type: 3}
+  - controllerType: 1071
+    handedness: 7
+    pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
+      type: 3}
+  - controllerType: 256
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,
+      type: 3}
+  - controllerType: 512
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 31d81f88cf3f71d4b8392ded50df3f05,
+      type: 3}
+  - controllerType: 1024
+    handedness: 7
+    pointerPrefab: {fileID: 1507865967819406, guid: 38b548c6a2c270545a383296ad2bc4d5,
+      type: 3}
+  - controllerType: 1024
+    handedness: 7
+    pointerPrefab: {fileID: 1507865967819406, guid: 526b854247016cf47bc5c58e01d82407,
+      type: 3}
+  - controllerType: 2048
+    handedness: 7
+    pointerPrefab: {fileID: 1247086986094436, guid: 039b325c9e8fd0545a0475fd4aa35b10,
+      type: 3}
+  pointerMediator:
+    reference: Microsoft.MixedReality.Toolkit.Input.DefaultPointerMediator, Microsoft.MixedReality.Toolkit.SDK
+  primaryPointerSelector:
+    reference: Microsoft.MixedReality.Toolkit.Input.DefaultPrimaryPointerSelector,
+      Microsoft.MixedReality.Toolkit.SDK

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputPointerProfile.asset.meta
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputPointerProfile.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 802acda43fc6a1a4a9af89c0e00eaecb
-PrefabImporter:
+guid: 6600ad36afe996246b8b1c99b63ccb32
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputProfile.asset
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputProfile.asset
@@ -42,7 +42,7 @@ MonoBehaviour:
     runtimePlatform: -1
     deviceManagerProfile: {fileID: 0}
   - componentType:
-      reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation.Editor
+      reference: Microsoft.MixedReality.Toolkit.Input.InputSimulationService, Microsoft.MixedReality.Toolkit.Services.InputSimulation
     componentName: Input Simulation Service
     priority: 0
     runtimePlatform: 208
@@ -73,7 +73,7 @@ MonoBehaviour:
     type: 2}
   inputActionRulesProfile: {fileID: 11400000, guid: 03945385d89102f41855bc8f5116b199,
     type: 2}
-  pointerProfile: {fileID: 11400000, guid: 48aa63a9725047b28d4137fd0834bc31, type: 2}
+  pointerProfile: {fileID: 11400000, guid: 6600ad36afe996246b8b1c99b63ccb32, type: 2}
   gesturesProfile: {fileID: 11400000, guid: bd7829a9b29409045a745b5a18299291, type: 2}
   speechCommandsProfile: {fileID: 11400000, guid: e8d0393e66374dae9646851a57dc6bc1,
     type: 2}

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Resources/MRTK-OculusConfig.asset
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Resources/MRTK-OculusConfig.asset
@@ -16,8 +16,9 @@ MonoBehaviour:
   ovrCameraRigPrefab: {fileID: 2343937678411072827, guid: e855e4c2a827daf45be5e0ca86dd6d05,
     type: 3}
   allowDevToManageAvatarPrefab: 0
-  localAvatarPrefab: {fileID: 1703282039130822552, guid: bc9433565454e104f9ac73600c65a612,
+  localAvatarPrefab: {fileID: 6297684789857299957, guid: bc9433565454e104f9ac73600c65a612,
     type: 3}
+  teleportPointerMode: 0
   customTeleportPointerPrefab: {fileID: 3315140749854082096, guid: 6f4e2804d6ac4944e99e1737f500bb7a,
     type: 3}
   useCustomHandMaterial: 1

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Resources/MRTK-OculusConfig.asset
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Resources/MRTK-OculusConfig.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   ovrCameraRigPrefab: {fileID: 2343937678411072827, guid: e855e4c2a827daf45be5e0ca86dd6d05,
     type: 3}
   allowDevToManageAvatarPrefab: 0
-  localAvatarPrefab: {fileID: 6297684789857299957, guid: bc9433565454e104f9ac73600c65a612,
+  localAvatarPrefab: {fileID: 1703282039130822552, guid: bc9433565454e104f9ac73600c65a612,
     type: 3}
   customTeleportPointerPrefab: {fileID: 3315140749854082096, guid: 6f4e2804d6ac4944e99e1737f500bb7a,
     type: 3}

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
@@ -36,6 +36,16 @@ namespace prvncher.MixedReality.Toolkit.Config
     [CreateAssetMenu(menuName = "MRTK-Quest/MRTK-OculusConfig")]
     public class MRTKOculusConfig : ScriptableObject
     {
+        /// <summary>
+        /// Enum used for controlling the teleport pointer activated by MRTK Quest controllers.
+        /// </summary>
+        public enum TeleportPointerMode
+        {
+            Custom,
+            Official,
+            None
+        }
+
         private static MRTKOculusConfig instance;
         public static MRTKOculusConfig Instance
         {
@@ -91,6 +101,15 @@ namespace prvncher.MixedReality.Toolkit.Config
         private GameObject localAvatarPrefab = null;
 
         [Header("Pointer Configuration")]
+        [SerializeField]
+        [Tooltip("Controls which teleport mode is utilized by MRTK-Quest controllers.")]
+        private TeleportPointerMode teleportPointerMode = TeleportPointerMode.Custom;
+
+        /// <summary>
+        /// Controls which teleport mode is utilized by MRTK-Quest controllers.
+        /// </summary>
+        public TeleportPointerMode ActiveTeleportPointerMode => teleportPointerMode;
+
         [SerializeField]
         [Tooltip("Custom teleport pointer prefab, to be managed directly by MRTK-Quest, given that MRTK doesn't currently support teleport with articulated hands.")]
         private GameObject customTeleportPointerPrefab = null;

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/OculusQuestInputManager.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/OculusQuestInputManager.cs
@@ -48,9 +48,8 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
         private Dictionary<Handedness, OculusQuestHand> inactiveHandCache = new Dictionary<Handedness, OculusQuestHand>();
         private Dictionary<Handedness, OculusQuestController> inactiveControllerCache = new Dictionary<Handedness, OculusQuestController>();
-/*
         private Dictionary<Handedness, CustomTeleportPointer> teleportPointers = new Dictionary<Handedness, CustomTeleportPointer>();
-*/
+
         private OVRCameraRig cameraRig;
 
         private OVRHand rightHand;
@@ -254,18 +253,19 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             {
                 controller.InputSource.Pointers[i].Controller = controller;
             }
-/*
-            if (MixedRealityToolkit.IsTeleportSystemEnabled)
+
+            if (MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.Custom && MixedRealityToolkit.IsTeleportSystemEnabled)
             {
                 if (!teleportPointers.TryGetValue(handedness, out CustomTeleportPointer pointer))
                 {
                     pointer = GameObject.Instantiate(MRTKOculusConfig.Instance.CustomTeleportPrefab).GetComponent<CustomTeleportPointer>();
+                    pointer.gameObject.SetActive(false);
                     teleportPointers.Add(handedness, pointer);
                 }
                 pointer.Controller = controller;
                 controller.TeleportPointer = pointer;
             }
-*/
+
             inputSystem?.RaiseSourceDetected(controller.InputSource, controller);
 
             trackedControllers.Add(handedness, controller);
@@ -298,7 +298,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             if (controller == null) return;
             CoreServices.InputSystem?.RaiseSourceLost(controller.InputSource, controller);
             trackedControllers.Remove(controller.ControllerHandedness);
-/*
+
             if (teleportPointers.TryGetValue(controller.ControllerHandedness, out CustomTeleportPointer pointer))
             {
                 if (pointer == null)
@@ -311,7 +311,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 }
                 controller.TeleportPointer = null;
             }
-*/
+
             RecyclePointers(controller.InputSource);
         }
         #endregion
@@ -360,6 +360,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 controller.UpdateAvatarMaterial(MRTKOculusConfig.Instance.CustomHandMaterial);
             }
         }
+
         private OculusQuestHand GetOrAddHand(Handedness handedness, OVRHand ovrHand)
         {
             if (trackedHands.ContainsKey(handedness))
@@ -385,18 +386,19 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             {
                 handController.InputSource.Pointers[i].Controller = handController;
             }
-/*
-            if (MixedRealityToolkit.IsTeleportSystemEnabled)
+
+            if (MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.Custom &&  MixedRealityToolkit.IsTeleportSystemEnabled)
             {
                 if (!teleportPointers.TryGetValue(handedness, out CustomTeleportPointer pointer))
                 {
                     pointer = GameObject.Instantiate(MRTKOculusConfig.Instance.CustomTeleportPrefab).GetComponent<CustomTeleportPointer>();
+                    pointer.gameObject.SetActive(false);
                     teleportPointers.Add(handedness, pointer);
                 }
                 pointer.Controller = handController;
                 handController.TeleportPointer = pointer;
             }
-*/
+
             inputSystem?.RaiseSourceDetected(handController.InputSource, handController);
 
             trackedHands.Add(handedness, handController);
@@ -427,7 +429,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
         private void RemoveHandDevice(OculusQuestHand hand)
         {
             if (hand == null) return;
-/*
+
             if (teleportPointers.TryGetValue(hand.ControllerHandedness, out CustomTeleportPointer pointer))
             {
                 if (pointer == null)
@@ -440,7 +442,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 }
                 hand.TeleportPointer = null;
             }
-*/
+
             hand.CleanupHand();
             inactiveHandCache.Add(hand.ControllerHandedness, hand);
 

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/OculusQuestInputManager.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/OculusQuestInputManager.cs
@@ -48,9 +48,9 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
         private Dictionary<Handedness, OculusQuestHand> inactiveHandCache = new Dictionary<Handedness, OculusQuestHand>();
         private Dictionary<Handedness, OculusQuestController> inactiveControllerCache = new Dictionary<Handedness, OculusQuestController>();
-
+/*
         private Dictionary<Handedness, CustomTeleportPointer> teleportPointers = new Dictionary<Handedness, CustomTeleportPointer>();
-
+*/
         private OVRCameraRig cameraRig;
 
         private OVRHand rightHand;
@@ -254,7 +254,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             {
                 controller.InputSource.Pointers[i].Controller = controller;
             }
-
+/*
             if (MixedRealityToolkit.IsTeleportSystemEnabled)
             {
                 if (!teleportPointers.TryGetValue(handedness, out CustomTeleportPointer pointer))
@@ -265,7 +265,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 pointer.Controller = controller;
                 controller.TeleportPointer = pointer;
             }
-
+*/
             inputSystem?.RaiseSourceDetected(controller.InputSource, controller);
 
             trackedControllers.Add(handedness, controller);
@@ -298,7 +298,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             if (controller == null) return;
             CoreServices.InputSystem?.RaiseSourceLost(controller.InputSource, controller);
             trackedControllers.Remove(controller.ControllerHandedness);
-
+/*
             if (teleportPointers.TryGetValue(controller.ControllerHandedness, out CustomTeleportPointer pointer))
             {
                 if (pointer == null)
@@ -311,6 +311,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 }
                 controller.TeleportPointer = null;
             }
+*/
             RecyclePointers(controller.InputSource);
         }
         #endregion
@@ -384,7 +385,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             {
                 handController.InputSource.Pointers[i].Controller = handController;
             }
-
+/*
             if (MixedRealityToolkit.IsTeleportSystemEnabled)
             {
                 if (!teleportPointers.TryGetValue(handedness, out CustomTeleportPointer pointer))
@@ -395,7 +396,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 pointer.Controller = handController;
                 handController.TeleportPointer = pointer;
             }
-
+*/
             inputSystem?.RaiseSourceDetected(handController.InputSource, handController);
 
             trackedHands.Add(handedness, handController);
@@ -426,7 +427,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
         private void RemoveHandDevice(OculusQuestHand hand)
         {
             if (hand == null) return;
-
+/*
             if (teleportPointers.TryGetValue(hand.ControllerHandedness, out CustomTeleportPointer pointer))
             {
                 if (pointer == null)
@@ -439,7 +440,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 }
                 hand.TeleportPointer = null;
             }
-
+*/
             hand.CleanupHand();
             inactiveHandCache.Add(hand.ControllerHandedness, hand);
 

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/TeleportPointer/CustomTeleportCursorHandler.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/TeleportPointer/CustomTeleportCursorHandler.cs
@@ -113,7 +113,7 @@ namespace prvncher.MixedReality.Toolkit.Input.Teleport
             startScale = PrimaryCursorVisual.localScale;
         }
 
-        private void Update()
+        private void LateUpdate()
         {
             if (!CanUpdateCursor)
             {


### PR DESCRIPTION
@machenmusik contributions:
- Made it possible to call the teleport input action for default teleport pointer

@provencher contributions:
- Added enum allowing for Custom teleport pointer, official teleport pointer, or no teleport pointer
- Fixed teleport cursor appearing at hand after first being instantiated
- Fixed teleport cursor updating a frame behind by moving its update to late update
- Fixed avatar prefab reference being broken by last commit