### PR TITLE
Fixes for 1.0.1

### DIFF
--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputPointerProfile.asset
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Profiles/MRTK-Quest_InputPointerProfile.asset
@@ -35,10 +35,6 @@ MonoBehaviour:
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: d5b94136462644c9873bb3347169ae7e,
       type: 3}
-  - controllerType: 1071
-    handedness: 7
-    pointerPrefab: {fileID: 1196247974088106, guid: c4fd3c6fc7ff484eb434775066e7f327,
-      type: 3}
   - controllerType: 256
     handedness: 7
     pointerPrefab: {fileID: 1247086986094436, guid: 51e60b8742bc47640923ac9e75ea74e9,

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
@@ -108,7 +108,15 @@ namespace prvncher.MixedReality.Toolkit.Config
         /// <summary>
         /// Controls which teleport mode is utilized by MRTK-Quest controllers.
         /// </summary>
-        public TeleportPointerMode ActiveTeleportPointerMode => teleportPointerMode;
+        public TeleportPointerMode ActiveTeleportPointerMode
+        {
+#if OVRPLUGIN_UNSUPPORTED_PLATFORM
+            // If the platform is not supported by oculus, we need to ensure we don't create a teleport pointer that can't be used.
+            get => TeleportPointerMode.None;
+#else
+            get => teleportPointerMode;
+#endif
+        }
 
         [SerializeField]
         [Tooltip("Custom teleport pointer prefab, to be managed directly by MRTK-Quest, given that MRTK doesn't currently support teleport with articulated hands.")]

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Config/MRTKOculusConfig.cs
@@ -102,11 +102,13 @@ namespace prvncher.MixedReality.Toolkit.Config
 
         [Header("Pointer Configuration")]
         [SerializeField]
-        [Tooltip("Controls which teleport mode is utilized by MRTK-Quest controllers.")]
+        [Tooltip("Controls which teleport mode is utilized by MRTK-Quest controllers." +
+                 "Note to use the official pointer, you must add a parabollic pointer to your pointer input profile that supports articulated hands.")]
         private TeleportPointerMode teleportPointerMode = TeleportPointerMode.Custom;
 
         /// <summary>
         /// Controls which teleport mode is utilized by MRTK-Quest controllers.
+        /// Note to use the official pointer, you must add a parabollic pointer to your pointer input profile that supports articulated hands.
         /// </summary>
         public TeleportPointerMode ActiveTeleportPointerMode
         {
@@ -119,7 +121,7 @@ namespace prvncher.MixedReality.Toolkit.Config
         }
 
         [SerializeField]
-        [Tooltip("Custom teleport pointer prefab, to be managed directly by MRTK-Quest, given that MRTK doesn't currently support teleport with articulated hands.")]
+        [Tooltip("Custom teleport pointer prefab, to be managed directly by MRTK-Quest, given that MRTK doesn't currently officially support teleport with articulated hands.")]
         private GameObject customTeleportPointerPrefab = null;
 
         /// <summary>

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/Controllers/OculusQuestController.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/Controllers/OculusQuestController.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using prvncher.MixedReality.Toolkit.Config;
 using prvncher.MixedReality.Toolkit.Input.Teleport;
 using UnityEngine;
+using TeleportPointer = Microsoft.MixedReality.Toolkit.Teleport.TeleportPointer;
 
 namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 {
@@ -89,10 +90,13 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
         protected readonly Dictionary<TrackedHandJoint, MixedRealityPose> jointPoses = new Dictionary<TrackedHandJoint, MixedRealityPose>();
 
         private const float cTriggerDeadZone = 0.1f;
+        private int pinchStrengthProp;
+
 
         public OculusQuestController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
             : base(trackingState, controllerHandedness, inputSource, interactions)
         {
+            pinchStrengthProp = Shader.PropertyToID(MRTKOculusConfig.Instance.PinchStrengthMaterialProperty);
         }
 
         /// <summary>
@@ -161,22 +165,36 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             }
 
             // Todo: Complete touch controller mapping
-
             bool isTriggerPressed;
+            float triggerValue;
+
             bool isGripPressed;
+            float gripValue;
+
             Vector2 stickInput;
+
             if (ControllerHandedness == Handedness.Left)
             {
-                isTriggerPressed = OVRInput.Get(OVRInput.RawAxis1D.LIndexTrigger) > cTriggerDeadZone;
-                isGripPressed = OVRInput.Get(OVRInput.RawAxis1D.LHandTrigger) > cTriggerDeadZone;
+                triggerValue = OVRInput.Get(OVRInput.RawAxis1D.LIndexTrigger);
+                isTriggerPressed = triggerValue > cTriggerDeadZone;
+
+                gripValue = OVRInput.Get(OVRInput.RawAxis1D.LHandTrigger);
+                isGripPressed = gripValue > cTriggerDeadZone;
+
                 stickInput = OVRInput.Get(OVRInput.RawAxis2D.LThumbstick);
             }
             else
             {
-                isTriggerPressed = OVRInput.Get(OVRInput.RawAxis1D.RIndexTrigger) > cTriggerDeadZone;
-                isGripPressed = OVRInput.Get(OVRInput.RawAxis1D.RHandTrigger) > cTriggerDeadZone;
+                triggerValue = OVRInput.Get(OVRInput.RawAxis1D.RIndexTrigger);
+                isTriggerPressed = triggerValue > cTriggerDeadZone;
+
+                gripValue = OVRInput.Get(OVRInput.RawAxis1D.RHandTrigger);
+                isGripPressed = gripValue > cTriggerDeadZone;
+
                 stickInput = OVRInput.Get(OVRInput.RawAxis2D.RThumbstick);
             }
+
+            UpdateHandPinchStrength(Mathf.Max(triggerValue, gripValue));
 
             bool isSelecting = isTriggerPressed || isGripPressed;
 
@@ -239,9 +257,10 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
         private void UpdateTeleport(Vector2 stickInput)
         {
-            if(MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.None) return;
+            if (MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.None) return;
 
             MixedRealityInputAction teleportAction = MixedRealityInputAction.None;
+            IMixedRealityTeleportPointer teleportPointer = TeleportPointer;
 
             // Check if we're focus locked or near something interactive to avoid teleporting unintentionally.
             bool anyPointersLockedWithHand = false;
@@ -255,13 +274,23 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 }
                 anyPointersLockedWithHand |= InputSource.Pointers[i].IsFocusLocked;
 
-                if (InputSource.Pointers[i] is IMixedRealityTeleportPointer)
+                // If official teleport mode and we have a teleport pointer registered, we get the input action to trigger it.
+                if (MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.Official
+                    && InputSource.Pointers[i] is IMixedRealityTeleportPointer)
                 {
-                    teleportAction = ((Microsoft.MixedReality.Toolkit.Teleport.TeleportPointer)InputSource.Pointers[i]).TeleportInputAction;
+                    teleportPointer = (TeleportPointer)InputSource.Pointers[i];
+                    teleportAction = ((TeleportPointer)teleportPointer).TeleportInputAction;
                 }
             }
 
             bool isReadyForTeleport = !anyPointersLockedWithHand && stickInput != Vector2.zero;
+
+            // If not ready for teleport, we raise a cancellation event to prevent accidental teleportation.
+            if (!isReadyForTeleport && teleportPointer != null)
+            {
+                CoreServices.TeleportSystem?.RaiseTeleportCanceled(teleportPointer, null);
+            }
+
             isInPointingPose = !isReadyForTeleport;
 
             RaiseTeleportInput(isInPointingPose ? Vector2.zero : stickInput, teleportAction, isReadyForTeleport);
@@ -273,7 +302,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             {
                 case MRTKOculusConfig.TeleportPointerMode.Custom:
                     if (TeleportPointer == null) return;
-                    TeleportPointer.gameObject.SetActive(isReadyForTeleport);
+                    TeleportPointer.gameObject.SetActive(IsPositionAvailable);
                     TeleportPointer.transform.position = currentPointerPose.Position;
                     TeleportPointer.transform.rotation = currentPointerPose.Rotation;
                     TeleportPointer.UpdatePointer(isReadyForTeleport, teleportInput);
@@ -286,7 +315,6 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                     return;
             }
         }
-
 
         /// <summary>
         /// Updates material instance used for avatar hands.
@@ -317,9 +345,18 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
         private void UpdateHandRenderers(GameObject handRoot)
         {
-            if(handRoot == null) return;
+            if (handRoot == null) return;
             handRenderers = new List<Renderer>(handRoot.GetComponentsInChildren<Renderer>());
             ApplyHandMaterial();
+        }
+
+        private void UpdateHandPinchStrength(float pinchStrength)
+        {
+            if (!MRTKOculusConfig.Instance.UpdateMaterialPinchStrengthValue || handMaterial == null) return;
+            foreach (var handRenderer in handRenderers)
+            {
+                handRenderer.sharedMaterial.SetFloat(pinchStrengthProp, pinchStrength);
+            }
         }
 
         private bool InitializeAvatarHandReferences()
@@ -339,7 +376,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             // With no root, no use in looking up other joints
             if (handRoot == null) return false;
 
-            string handMeshRoot = "hand_" + (ControllerHandedness == Handedness.Left ? "left" : "right"); 
+            string handMeshRoot = "hand_" + (ControllerHandedness == Handedness.Left ? "left" : "right");
             UpdateHandRenderers(GameObject.Find(handMeshRoot));
 
             // If we have a hand root match, we look up all other hand joints
@@ -516,7 +553,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 Vector3 middle3Position = middleKnucklePose.Position;
 
                 Vector3 palmPosition = Vector3.Lerp(wristRootPosition, middle3Position, 0.5f);
-                Quaternion palmRotation = CorrectPalmRotation(wristPose.Rotation); 
+                Quaternion palmRotation = CorrectPalmRotation(wristPose.Rotation);
 
                 UpdateJointPose(TrackedHandJoint.Palm, palmPosition, palmRotation);
             }

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/Controllers/OculusQuestHand.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/Controllers/OculusQuestHand.cs
@@ -160,6 +160,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
         {
             get
             {
+                if (MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.None) return false;
                 if (!TryGetJoint(TrackedHandJoint.Palm, out var palmPose)) return false;
 
                 Transform cameraTransform = CameraCache.Main.transform;

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/Controllers/OculusQuestHand.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Input/DeviceManager/Controllers/OculusQuestHand.cs
@@ -36,6 +36,7 @@ using prvncher.MixedReality.Toolkit.Utils;
 using UnityEngine;
 using static OVRSkeleton;
 using Object = UnityEngine.Object;
+using TeleportPointer = Microsoft.MixedReality.Toolkit.Teleport.TeleportPointer;
 
 namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 {
@@ -66,6 +67,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
         private bool isIndexGrabbing = false;
         private bool isMiddleGrabbing = false;
+        private bool isThumbGrabbing = false;
 
         private int pinchStrengthProp;
 
@@ -149,7 +151,25 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 Vector3 projectedPalmUp = Vector3.ProjectOnPlane(-palmPose.Up, cameraTransform.up);
 
                 // We check if the palm forward is roughly in line with the camera lookAt
-                return Vector3.Dot(cameraTransform.forward, projectedPalmUp) > 0.3f && Vector3.Dot(-palmPose.Up, Vector3.up) < 0.5f;
+                // We must also ensure we're not in teleport pose
+                return Vector3.Dot(cameraTransform.forward, projectedPalmUp) > 0.3f && !IsInTeleportPose;
+            }
+        }
+
+        protected bool IsInTeleportPose
+        {
+            get
+            {
+                if (!TryGetJoint(TrackedHandJoint.Palm, out var palmPose)) return false;
+
+                Transform cameraTransform = CameraCache.Main.transform;
+
+                Vector3 projectedPalmUp = Vector3.ProjectOnPlane(-palmPose.Up, cameraTransform.forward);
+
+                // We check if the palm up is roughly in line with the camera up
+                return Vector3.Dot(-palmPose.Up, cameraTransform.up) > 0.6f
+                       // Thumb must be extended, and middle must be grabbing
+                       && !isThumbGrabbing && isMiddleGrabbing;
             }
         }
 
@@ -253,6 +273,8 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
             MixedRealityInputAction teleportAction = MixedRealityInputAction.None;
 
+            IMixedRealityTeleportPointer teleportPointer = TeleportPointer;
+
             // Check if we're focus locked or near something interactive to avoid teleporting unintentionally.
             bool anyPointersLockedWithHand = false;
             for (int i = 0; i < InputSource?.Pointers?.Length; i++)
@@ -265,15 +287,23 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
                 }
                 anyPointersLockedWithHand |= InputSource.Pointers[i].IsFocusLocked;
 
-                if (InputSource.Pointers[i] is IMixedRealityTeleportPointer)
+                // If official teleport mode and we have a teleport pointer registered, we get the input action to trigger it.
+                if (MRTKOculusConfig.Instance.ActiveTeleportPointerMode == MRTKOculusConfig.TeleportPointerMode.Official
+                    && InputSource.Pointers[i] is IMixedRealityTeleportPointer)
                 {
-                    teleportAction = ((Microsoft.MixedReality.Toolkit.Teleport.TeleportPointer)InputSource.Pointers[i]).TeleportInputAction;
+                    teleportPointer = (TeleportPointer)InputSource.Pointers[i];
+                    teleportAction = ((TeleportPointer)teleportPointer).TeleportInputAction;
                 }
             }
 
             // We close middle finger to signal spider-man gesture, and as being ready for teleport
-            bool isReadyForTeleport = !anyPointersLockedWithHand && IsPositionAvailable && !IsInPointingPose &&
-                                      isMiddleGrabbing;
+            bool isReadyForTeleport = !anyPointersLockedWithHand && IsPositionAvailable && IsInTeleportPose;
+
+            // If not ready for teleport, we raise a cancellation event to prevent accidental teleportation.
+            if (!isReadyForTeleport && teleportPointer != null)
+            {
+                CoreServices.TeleportSystem?.RaiseTeleportCanceled(teleportPointer, null);
+            }
 
             Vector2 stickInput = isReadyForTeleport ? Vector2.up : Vector2.zero;
 
@@ -286,7 +316,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
             {
                 case MRTKOculusConfig.TeleportPointerMode.Custom:
                     if (TeleportPointer == null) return;
-                    TeleportPointer.gameObject.SetActive(isReadyForTeleport);
+                    TeleportPointer.gameObject.SetActive(IsPositionAvailable);
                     TeleportPointer.transform.position = currentPointerPose.Position;
                     TeleportPointer.transform.rotation = currentPointerPose.Rotation;
                     TeleportPointer.UpdatePointer(isReadyForTeleport, teleportInput);
@@ -407,6 +437,7 @@ namespace prvncher.MixedReality.Toolkit.OculusQuestInput
 
             isIndexGrabbing = HandPoseUtils.IsIndexGrabbing(ControllerHandedness);
             isMiddleGrabbing = HandPoseUtils.IsMiddleGrabbing(ControllerHandedness);
+            isThumbGrabbing = HandPoseUtils.IsThumbGrabbing(ControllerHandedness);
 
             // Pinch was also used as grab, we want to allow hand-curl grab not just pinch.
             // Determine pinch and grab separately

--- a/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Utils/HandPoseUtils.cs
+++ b/Assets/MRTK.ThirdParty/MRTK-Quest/Scripts/Utils/HandPoseUtils.cs
@@ -71,5 +71,24 @@ namespace prvncher.MixedReality.Toolkit.Utils
             }
             return false;
         }
+
+        /// <summary>
+        /// Returns true if middle thumb tip is closer to pinky knuckle than thumb knuckle joint.
+        /// </summary>
+        /// <param name="hand">Hand to query joint pose against.</param>
+        /// <returns></returns>
+        public static bool IsThumbGrabbing(Handedness hand)
+        {
+            if (HandJointUtils.TryGetJointPose(TrackedHandJoint.PinkyKnuckle, hand, out var pinkyKnucklePose) &&
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.ThumbTip, hand, out var thumbTipPose) &&
+                HandJointUtils.TryGetJointPose(TrackedHandJoint.ThumbProximalJoint, hand, out var thumbKnucklePose))
+            {
+                // compare pinkyKnuckle-ThumbKnuckle to pinkyKnuckle-ThumbTip
+                Vector3 pinkyKnuckleToThumbTip = thumbTipPose.Position - pinkyKnucklePose.Position;
+                Vector3 pinkyKnuckleToThumbKnuckle = thumbKnucklePose.Position - pinkyKnucklePose.Position;
+                return pinkyKnuckleToThumbKnuckle.sqrMagnitude >= pinkyKnuckleToThumbTip.sqrMagnitude;
+            }
+            return false;
+        }
     }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,7 +7,7 @@
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.0",
-    "com.unity.multiplayer-hlapi": "1.0.4",
+    "com.unity.multiplayer-hlapi": "1.0.6",
     "com.unity.purchasing": "2.0.6",
     "com.unity.test-framework": "1.1.14",
     "com.unity.textmeshpro": "2.0.1",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -124,7 +124,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.0.0
+  bundleVersion: 1.0.1
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.15f1
-m_EditorVersionWithRevision: 2019.3.15f1 (59ff3e03856d)
+m_EditorVersion: 2019.4.0f1
+m_EditorVersionWithRevision: 2019.4.0f1 (0af376155913)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ It was built to showcase the hand-driven interaction model designed by Microsoft
 - Full support for articulated hand tracking, and simulated hand tracking using controllers with avatar hands.
 - Support for Oculus Link on Quest with controllers, which means rapid iteration without builds.
 - Full support for any interaction in the MRTK designed to work for HoloLens 2.
+- Teleport! MRTK-Quest is currently the only way to integrate support for teleporting with articulated hand tracking in MRTK.
 
 ## Demo Video
 [![Demo video](https://user-images.githubusercontent.com/7420990/83885080-dcde6100-a713-11ea-88e2-46883402cfe8.gif)](https://twitter.com/prvncher/status/1268901965175668736)
 
 # Supported versions
-- Unity 2019.3.15f1
+- Unity 2019.4.0f1
 - Oculus Integration 17.0
 - Mixed Reality Toolkit v2.4.0+
 
@@ -106,14 +107,18 @@ MRTK has a Project Configuration modal window that pops up when you first open a
 - **MultiThreaded Rendering** The project configuration window will attempt to disable this option, 
 however, from my testing with Quest, it works properly, and improves performance.
 
-
 ## 5. MRTK-Quest Integration Configuration
 New Config scriptable object exposing hand mesh material and performance seetings.
 This is a project singleton located in Resources/MRTK-OculusConfig    
 ![image](https://user-images.githubusercontent.com/7420990/80736858-b871e200-8ae0-11ea-869a-60b6df212365.png)
 
+## 6. Teleport Configuration
+Teleport support now comes in a few flavors. To make use of either supported mode, you must enable the teleport system in your profile.
+- Custom. This is the fully configured version that includes audio and improved visuals. It is enabled by default.
+- Official. This version can be set in the MRTK-OculusConfig. Enabling this requires also adding the Parabollic pointer to the Input Pointer Profile. This pointer is less well tested, but will receive updates alongside MRTK versions.
+- None. This completely de-activates the teleport pointer from MRTK-Quest.
 
-## 6. Community and support
+## 7. Community and support
 If you'd like to discuss your issues or ideas to improve this project, please join us over on the [HoloDevs Slack](https://holodevelopersslack.azurewebsites.net/).
 There is a public channel called #MRTK-Quest.
 


### PR DESCRIPTION
# Teleport Activation improvements (#61) 
- Improvements to teleport gestures: Thumb must be extended, palm up must align with camera up.
-  Improvements to teleport mode activation: Instead of disabling teleport pointer when not in correct teleport pose, raise teleport cancelled event to prevent teleport popping in, as well as to prevent accidental activation.
- Fixed bug where teleport pointer would get instantiated on unsupported platforms.
- Removed parabollic pointer from input pointer profile by default to prevent errors from missing data, and conflicts with custom pointer.

# Polish 
- Added pinch strength affordance to controller grip and trigger press.

# Dependencies
- Upgrade project to 2019.4.0f1
